### PR TITLE
fix: Remove ScoreProgress props

### DIFF
--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -73,7 +73,6 @@ export default function ResultPage() {
 
         {/* 점수 섹션 */}
         <ScoreProgress
-          prediction={analysisResult?.prediction || '주의'}
           riskProbability={analysisResult?.risk_probability || '0%'}
           size={240}
           strokeWidth={14}


### PR DESCRIPTION
The prediction prop was removed from the ScoreProgress component in ResultPage as it is no longer used.